### PR TITLE
Add global scroll progress bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import "aos/dist/aos.css";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import Navbar from "./components/Navbar";
+import ScrollProgress from "./components/ScrollProgress";
 import HeroSection from "./components/HeroSection";
 import FeatureCarousel from "./components/FeatureCarousel";
 import NewsletterSignup from "./components/NewsletterSignup";
@@ -26,6 +27,7 @@ function App() {
 
   return (
     <div className="App min-h-screen flex flex-col">
+      <ScrollProgress />
       <Navbar />
       <div className="flex-grow">
         <TransitionGroup>

--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -1,0 +1,14 @@
+import { motion, useScroll, useSpring } from 'framer-motion';
+
+const ScrollProgress = () => {
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress);
+  return (
+    <motion.div
+      className="fixed top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 to-emerald-500 z-50"
+      style={{ scaleX }}
+    />
+  );
+};
+
+export default ScrollProgress;

--- a/src/pages/SAM.jsx
+++ b/src/pages/SAM.jsx
@@ -26,11 +26,6 @@ const SAM = () => {
 
   return (
     <div ref={containerRef} className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900">
-      {/* Progress bar */}
-      <motion.div
-        className="fixed top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 to-emerald-500"
-        style={{ scaleX }}
-      />
 
       {/* Hero Section */}
       <div className="relative h-screen flex items-center justify-center overflow-hidden">


### PR DESCRIPTION
## Summary
- create `ScrollProgress` component for page scroll indicator
- use `ScrollProgress` in `App` to show progress on every page
- remove SAM-specific progress bar

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841131d4b3c8333a7b4101a1d2c9187